### PR TITLE
feat: created Interview section

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -21,3 +21,6 @@ body {
 .SideBarMenu :hover{
     color: white !important;
 }
+/* button, [type='button'], [type='reset'], [type='submit'] {
+    background-color: #1677ff !important;
+} */

--- a/client/src/app/interfaces.ts
+++ b/client/src/app/interfaces.ts
@@ -1,0 +1,15 @@
+export interface User {
+  email: string;
+  username: string;
+  _v: number;
+  _id: string;
+}
+
+export enum ProfessionType {
+  ALL = 'all',
+  SOFTWARE_ENGINEER = 'Software Engineer',
+  DATA_SCIENTIST = 'Data Scientist',
+  PRODUCT_MANAGER = 'Product Manager',
+}
+
+export type Profession = ProfessionType;

--- a/client/src/app/start/dashboard/page.tsx
+++ b/client/src/app/start/dashboard/page.tsx
@@ -4,10 +4,13 @@ import React from 'react';
 import { Button, Dropdown, Space } from 'antd';
 import { DownOutlined, UserOutlined } from '@ant-design/icons';
 import { MenuProps } from 'antd';
+import { useRouter } from 'next/navigation';
+import { ProfessionType } from '@/app/interfaces';
 
 export default function Dashboard() {
   const [profession, setProfession] = useState('Software Engineer');
   const [numberQuestions, setNumberQuestions] = useState(1);
+  const router = useRouter();
 
   const handleMenuClick: MenuProps['onClick'] = (e) => {
     setProfession(e.key);
@@ -17,19 +20,25 @@ export default function Dashboard() {
     setNumberQuestions(parseInt(e.key));
   };
 
+  const startInterview = () => {
+    router.push(
+      `/start/interview?profession=${profession}&numberQs=${numberQuestions}`,
+    );
+  };
+
   const items: MenuProps['items'] = [
     {
-      label: 'Software Engineer',
+      label: ProfessionType.SOFTWARE_ENGINEER,
       key: 'Software Engineer',
       icon: <UserOutlined />,
     },
     {
-      label: 'Data Scientist',
+      label: ProfessionType.DATA_SCIENTIST,
       key: 'Data Scientist',
       icon: <UserOutlined />,
     },
     {
-      label: 'Product Manager',
+      label: ProfessionType.PRODUCT_MANAGER,
       key: 'Product Manager',
       icon: <UserOutlined />,
     },
@@ -96,7 +105,10 @@ export default function Dashboard() {
             </Dropdown>
           </div>
           <div className="flex md:col-span-3 justify-center">
-            <Button className="h-10 w-52 md:w-36 lg:w-52 bg-[#3772FF] rounded-md text-white text-base font-medium">
+            <Button
+              className="h-10 w-52 md:w-36 lg:w-52 bg-[#3772FF] rounded-md text-white text-base font-medium"
+              onClick={() => startInterview()}
+            >
               Begin Interview
             </Button>
           </div>

--- a/client/src/app/start/feedback/page.tsx
+++ b/client/src/app/start/feedback/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+
+export default function Feedback() {
+  return (
+    <div className="lg:max-w-screen-lg lg:mx-auto flex flex-col w-full mt-8 gap-16 lg:gap-36">
+      <div className="flex flex-col gap-4 mx-auto md:mx-auto px-4 md:px-0 md:w-11/12 w-10/12">
+        <p className="text-2xl font-bold">Feedback</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/start/history/page.tsx
+++ b/client/src/app/start/history/page.tsx
@@ -9,7 +9,7 @@ export default function History() {
       <div className="flex flex-col gap-4 mx-auto md:mx-auto px-4 md:px-0 md:w-11/12 w-10/12">
         <p className="text-2xl font-bold">History</p>
       </div>
-      <div className='flex flex-col gap-2 mx-auto px-4 md:px-0 md:w-11/12 w-10/12'>
+      <div className="flex flex-col gap-2 mx-auto px-4 md:px-0 md:w-11/12 w-10/12">
         Nothing
       </div>
     </div>

--- a/client/src/app/start/history/page.tsx
+++ b/client/src/app/start/history/page.tsx
@@ -1,11 +1,16 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function History() {
+  const [previousInterviews, setPreviousInterviews] = useState([]);
+
   return (
-    <div className="lg:max-w-screen-lg lg:mx-auto flex flex-col w-full mt-8 gap-16 lg:gap-36">
+    <div className="lg:max-w-screen-lg lg:mx-auto flex flex-col w-full mt-8 gap-8 lg:gap-12">
       <div className="flex flex-col gap-4 mx-auto md:mx-auto px-4 md:px-0 md:w-11/12 w-10/12">
         <p className="text-2xl font-bold">History</p>
+      </div>
+      <div className='flex flex-col gap-2 mx-auto px-4 md:px-0 md:w-11/12 w-10/12'>
+        Nothing
       </div>
     </div>
   );

--- a/client/src/app/start/interview/page.tsx
+++ b/client/src/app/start/interview/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import GetQuestions from '@/app/utils/get-questions';
+import { useRouter, useSearchParams } from 'next/navigation';
+import getProfessionType from '@/app/utils/get-profession-type';
+import Card from 'antd/es/card/Card';
+import { AudioOutlined, AudioMutedOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+
+export default function Interview() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const profession = getProfessionType(params.get('profession'));
+  const numQs = parseInt(
+    params.get('numberQs') ? String(params.get('numberQs')) : '0',
+  );
+
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [questions, setQuestions] = useState<string[]>([]);
+
+  const [muted, setMuted] = useState(false);
+
+  const nextQuestion = () => {
+    if (questionIndex >= questions.length - 1) {
+      // make a function that ends the interview, leads to result screen
+      router.push('/start/feedback');
+    } else {
+      setQuestionIndex(questionIndex + 1);
+    }
+  };
+
+  useEffect(() => {
+    const questions = GetQuestions(profession ? profession : undefined, numQs);
+    setQuestions(questions);
+  }, []);
+
+  const CardTitleUI = () => {
+    return (
+      <div className="flex justify-between">
+        <div>
+          <p>
+            Question {questionIndex + 1} of {numQs}
+          </p>
+        </div>
+        <div className="flex">
+          {!muted ? (
+            <AudioOutlined onClick={() => setMuted(!muted)} />
+          ) : (
+            <AudioMutedOutlined onClick={() => setMuted(!muted)} />
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="lg:max-w-screen-lg lg:mx-auto lg:justify-normal flex flex-col w-full mt-8 gap-16 lg:gap-36 h-full justify-center">
+      <Card title={CardTitleUI()}>
+        <div className="flex flex-col gap-5">
+          <div>{questions[questionIndex]}</div>
+          <Button onClick={nextQuestion} size="middle" className="w-44">
+            Submit Response
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/app/start/layout.tsx
+++ b/client/src/app/start/layout.tsx
@@ -2,7 +2,7 @@
 
 import '../globals.css';
 import React, { useEffect, useState } from 'react';
-import { Layout, Menu, MenuProps } from 'antd';
+import { Layout, Menu, MenuProps, Modal } from 'antd';
 const { Footer, Sider } = Layout;
 import { Suspense } from 'react';
 import Loading from './loading';
@@ -14,8 +14,8 @@ import {
   LogoutOutlined,
 } from '@ant-design/icons';
 import axios from 'axios';
-import { useRouter } from 'next/navigation';
-import { User } from '../utils/interfaces';
+import { usePathname, useRouter } from 'next/navigation';
+import { User } from '../interfaces';
 import Logo from '../../../public/images/LogoV2.png';
 
 type MenuItem = Required<MenuProps>['items'][number];
@@ -50,7 +50,27 @@ export default function RegularLayout({
     _id: '',
   });
   const [selectedMenuItem, setSelectedMenuItem] = useState('');
+  const [movingToo, setMovingToo] = useState<string | null>('');
   const router = useRouter();
+  const path = usePathname();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const showModal = (path: string) => {
+    setIsModalOpen(true);
+    setMovingToo(path);
+  };
+
+  const handleOk = () => {
+    if (movingToo) {
+      setIsModalOpen(false);
+      router.push(movingToo);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
 
   const handleLogout = () => {
     axios
@@ -101,7 +121,11 @@ export default function RegularLayout({
               className="flex gap-2 justify-center items-center w-11/12 mx-auto rounded-md mt-5 mb-5 cursor-pointer"
               onClick={() => {
                 setSelectedMenuItem('');
-                router.push('/start/dashboard');
+                if (path.includes('interview')) {
+                  showModal('/start/dashboard');
+                } else {
+                  router.push('/start/dashboard');
+                }
               }}
             >
               <Image
@@ -121,7 +145,11 @@ export default function RegularLayout({
                   handleLogout();
                 } else if (info.key === 'history') {
                   setSelectedMenuItem(info.key);
-                  router.push('/start/history');
+                  if (path.includes('interview')) {
+                    showModal('/start/history');
+                  } else {
+                    router.push('/start/history');
+                  }
                 }
               }}
               selectedKeys={[selectedMenuItem]}
@@ -131,7 +159,7 @@ export default function RegularLayout({
             className="site-layout min-h-screen grid grid-rows-10"
             style={{ background: 'white' }}
           >
-            <div className="row-span-9">
+            <div className="row-span-9 h-full">
               <Suspense fallback={<Loading />}>{children}</Suspense>
             </div>
             <Footer
@@ -156,6 +184,16 @@ export default function RegularLayout({
           </Layout>
         </Layout>
       </div>
+      <Modal
+        title="Are you sure you want to end your interview?"
+        open={isModalOpen}
+        onOk={handleOk}
+        onCancel={handleCancel}
+        cancelText={'Go Back'}
+        okType="default"
+      >
+        <p>Youre progress will not be saved!</p>
+      </Modal>
     </Suspense>
   );
 }

--- a/client/src/app/start/layout.tsx
+++ b/client/src/app/start/layout.tsx
@@ -90,6 +90,9 @@ export default function RegularLayout({
           },
         );
         setUser(res.data.user);
+        if (!res.data.user) {
+          router.push('/welcome');
+        }
       } catch (error) {
         console.log(error);
       }

--- a/client/src/app/utils/get-profession-type.ts
+++ b/client/src/app/utils/get-profession-type.ts
@@ -1,0 +1,15 @@
+import { ProfessionType } from '../interfaces';
+
+export default function getProfessionType(
+  input: string | null,
+): ProfessionType | null {
+  if (input) {
+    for (const profession of Object.values(ProfessionType)) {
+      if (input === profession) {
+        return profession;
+      }
+    }
+    return null;
+  }
+  return null;
+}

--- a/client/src/app/utils/get-questions.ts
+++ b/client/src/app/utils/get-questions.ts
@@ -1,0 +1,23 @@
+import { ProfessionType } from '../interfaces';
+import { questionBank } from './questionBank';
+
+export default function GetQuestions(
+  profession: ProfessionType | undefined,
+  numberQs: number | undefined,
+): string[] {
+  const res: string[] = [];
+  if (profession && numberQs) {
+    for (let i = 0; i < numberQs; i++) {
+      let randomIndex = Math.floor(Math.random() * questionBank.length);
+      if (
+        questionBank[randomIndex][1] !== profession ||
+        questionBank[randomIndex][1] !== ProfessionType.ALL ||
+        res.includes(questionBank[randomIndex][0])
+      ) {
+        randomIndex = Math.floor(Math.random() * questionBank.length);
+      }
+      res.push(questionBank[randomIndex][0]);
+    }
+  }
+  return res;
+}

--- a/client/src/app/utils/interfaces.ts
+++ b/client/src/app/utils/interfaces.ts
@@ -1,6 +1,0 @@
-export interface User {
-  email: string;
-  username: string;
-  _v: number;
-  _id: string;
-}

--- a/client/src/app/utils/questionBank.ts
+++ b/client/src/app/utils/questionBank.ts
@@ -1,0 +1,44 @@
+import { Profession, ProfessionType } from '../interfaces';
+
+const questionBank: [string, Profession][] = [
+  [
+    'Say you are working on a team and someone has a different viewpoint on it, such as using a different programming language, how would handle this situation?',
+    ProfessionType.SOFTWARE_ENGINEER,
+  ],
+  ['Tell me about a project you are proud of', ProfessionType.ALL],
+  [
+    'Tell me about a time when you noticed someone was not being fully included in your team, how did you resolve this?',
+    ProfessionType.ALL,
+  ],
+  [
+    'Tell me about a time you volunteered to take on a significant assignment outside of your comfort zone in order to expand your capabilities. How often have you done this? What did you learn?',
+    ProfessionType.ALL,
+  ],
+  [
+    'Describe a situation in which you were a member of a group where teamwork was critical to getting something accomplished. I would like to know about your role, your approach to accomplishing the work, and any obstacles you faced.',
+    ProfessionType.ALL,
+  ],
+  [
+    'What is one area of growth that you believe this role would support you in improving in?',
+    ProfessionType.ALL,
+  ],
+  [
+    'Describe a time you received difficult feedback. What was the feedback and how did you react?',
+    ProfessionType.ALL,
+  ],
+  [
+    'What personal or professional mistakes have you learned the most from?',
+    ProfessionType.ALL,
+  ],
+  [
+    'What personal or professional accomplishments are you most proud of?',
+    ProfessionType.ALL,
+  ],
+  ['What inspires you to want to work in this industry?', ProfessionType.ALL],
+  [
+    'Tell me about a time your original plan for something fell through. How did you pivot? What was the outcome?',
+    ProfessionType.ALL,
+  ],
+];
+
+export { questionBank };


### PR DESCRIPTION
## Description

This PR creates the front end of the interview portion of the application. It involves:
- Creating a type for professions for code maintainability.
- Creating an initial question bank.
- Helper functions to determine which random question gets chosen and which profession is selected.
- Confirmation modal for when a user attempts to end an interview early.

## Notes
- Still need to test if users can access `/start` components even when not signed in, #12 

fixes 